### PR TITLE
fix: use the context from QueryContext instead of conn

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -88,7 +88,7 @@ func (dc *DatabendConn) query(ctx context.Context, query string, args ...driver.
 	if r0.Error != nil {
 		return nil, fmt.Errorf("query has error: %+v", r0.Error)
 	}
-	return newNextRows(dc, r0)
+	return newNextRows(ctx, dc, r0)
 }
 
 //func (dc *DatabendConn) Begin() (driver.Tx, error) {
@@ -166,7 +166,7 @@ func (dc *DatabendConn) Close() error {
 }
 
 func (dc *DatabendConn) Exec(query string, args []driver.Value) (driver.Result, error) {
-	return dc.exec(context.Background(), query, args...)
+	return dc.exec(dc.ctx, query, args...)
 }
 
 func (dc *DatabendConn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
@@ -178,7 +178,7 @@ func (dc *DatabendConn) ExecContext(ctx context.Context, query string, args []dr
 }
 
 func (dc *DatabendConn) Query(query string, args []driver.Value) (driver.Rows, error) {
-	return dc.query(context.Background(), query, args...)
+	return dc.query(dc.ctx, query, args...)
 }
 
 func (dc *DatabendConn) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {

--- a/const.go
+++ b/const.go
@@ -3,6 +3,7 @@ package godatabend
 const (
 	DatabendTenantHeader    = "X-DATABEND-TENANT"
 	DatabendWarehouseHeader = "X-DATABEND-WAREHOUSE"
+	DatabendQueryIDHeader   = "X-DATABEND-QUERY-ID"
 	Authorization           = "Authorization"
 	WarehouseRoute          = "X-DATABEND-ROUTE"
 	UserAgent               = "User-Agent"

--- a/query.go
+++ b/query.go
@@ -72,6 +72,8 @@ type QueryRequest struct {
 	StageAttachment *StageAttachmentConfig `json:"stage_attachment,omitempty"`
 }
 
+type QueryIDGenerator func() string
+
 type PaginationConfig struct {
 	WaitTime        int64 `json:"wait_time_secs,omitempty"`
 	MaxRowsInBuffer int64 `json:"max_rows_in_buffer,omitempty"`

--- a/restful_test.go
+++ b/restful_test.go
@@ -16,7 +16,7 @@ func TestMakeHeadersUserPassword(t *testing.T) {
 		host:     "localhost:8000",
 		tenant:   "default",
 	}
-	headers, err := c.makeHeaders()
+	headers, err := c.makeHeaders(context.TODO())
 	assert.Nil(t, err)
 	assert.Equal(t, headers["Authorization"], []string{"Basic cm9vdDpyb290"})
 	assert.Equal(t, headers["X-Databend-Tenant"], []string{"default"})
@@ -29,7 +29,7 @@ func TestMakeHeadersAccessToken(t *testing.T) {
 		accessTokenLoader: NewStaticAccessTokenLoader("abc123"),
 		warehouse:         "small-abc",
 	}
-	headers, err := c.makeHeaders()
+	headers, err := c.makeHeaders(context.TODO())
 	assert.Nil(t, err)
 	assert.Equal(t, headers["Authorization"], []string{"Bearer abc123"})
 	assert.Equal(t, headers["X-Databend-Tenant"], []string{"tn3ftqihs"})

--- a/rows_test.go
+++ b/rows_test.go
@@ -1,6 +1,7 @@
 package godatabend
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -8,7 +9,7 @@ import (
 )
 
 func TestTextRows(t *testing.T) {
-	rows, err := newNextRows(&DatabendConn{}, &QueryResponse{
+	rows, err := newNextRows(context.Background(), &DatabendConn{}, &QueryResponse{
 		Data: [][]string{{"1", "2", "3"}, {"3", "2", "1"}},
 		Schema: []DataField{
 			{Name: "age", Type: "Int32"},


### PR DESCRIPTION
when using the driver, it's more common to use the context from QueryContext. the privious PR misused the context from the conn.

this PR also added a context key about query id to allow passing query id in QueryContext.