### PR TITLE
fix: process session settings properly

### DIFF
--- a/restful.go
+++ b/restful.go
@@ -304,9 +304,11 @@ func (c *APIClient) applySessionConfig(response *QueryResponse) {
 		c.database = response.Session.Database
 	}
 	if response.Session.Settings != nil {
+		newSessionSettings := map[string]string{}
 		for k, v := range response.Session.Settings {
-			c.sessionSettings[k] = v
+			newSessionSettings[k] = v
 		}
+		c.sessionSettings = newSessionSettings
 	}
 }
 


### PR DESCRIPTION
fixes #79

now the query backend will response the complete settings set, to handle unset properly, all we need is overwrite the entire settings.