### PR TITLE
feat: handle secondary roles in the session

### DIFF
--- a/query.go
+++ b/query.go
@@ -27,14 +27,14 @@ type DataField struct {
 }
 
 type QueryResponse struct {
-	ID        string         `json:"id"`
-	SessionID string         `json:"session_id"`
-	Session   *SessionConfig `json:"session"`
-	Schema    []DataField    `json:"schema"`
-	Data      [][]string     `json:"data"`
-	State     string         `json:"state"`
-	Error     *QueryError    `json:"error"`
-	Stats     QueryStats     `json:"stats"`
+	ID        string        `json:"id"`
+	SessionID string        `json:"session_id"`
+	Session   *SessionState `json:"session"`
+	Schema    []DataField   `json:"schema"`
+	Data      [][]string    `json:"data"`
+	State     string        `json:"state"`
+	Error     *QueryError   `json:"error"`
+	Stats     QueryStats    `json:"stats"`
 	// TODO: Affect rows
 	StatsURI string `json:"stats_uri"`
 	FinalURI string `json:"final_uri"`
@@ -62,7 +62,7 @@ type QueryRequest struct {
 	// We use client session instead of server session with session_id
 	// SessionID  string            `json:"session_id,omitempty"`
 
-	Session    *SessionConfig    `json:"session,omitempty"`
+	Session    *SessionState     `json:"session,omitempty"`
 	SQL        string            `json:"sql"`
 	Pagination *PaginationConfig `json:"pagination,omitempty"`
 
@@ -80,9 +80,10 @@ type PaginationConfig struct {
 	MaxRowsPerPage  int64 `json:"max_rows_per_page,omitempty"`
 }
 
-type SessionConfig struct {
-	Database string `json:"database,omitempty"`
-	Role     string `json:"role,omitempty"`
+type SessionState struct {
+	Database       string    `json:"database,omitempty"`
+	Role           string    `json:"role,omitempty"`
+	SecondaryRoles *[]string `json:"secondary_roles,omitempty"`
 
 	// Since we use client session, this should not be used
 	// KeepServerSessionSecs uint64            `json:"keep_server_session_secs,omitempty"`

--- a/query_test.go
+++ b/query_test.go
@@ -1,0 +1,36 @@
+package godatabend
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/test-go/testify/require"
+)
+
+func Test_SessionState(t *testing.T) {
+	ss := &SessionState{
+		Database:       "db1",
+		Role:           "",
+		SecondaryRoles: nil,
+		Settings:       map[string]string{},
+	}
+	buf, err := json.Marshal(ss)
+	require.NoError(t, err)
+	assert.Equal(t, `{"database":"db1"}`, string(buf))
+
+	buf = []byte(`{"database":"db1", "secondary_roles": []}`)
+	err = json.Unmarshal(buf, ss)
+	require.NoError(t, err)
+	assert.Equal(t, []string{}, *ss.SecondaryRoles)
+
+	buf = []byte(`{"database":"db1", "secondary_roles": null}`)
+	err = json.Unmarshal(buf, ss)
+	require.NoError(t, err)
+	assert.Nil(t, ss.SecondaryRoles)
+
+	buf = []byte(`{"database":"db1"}`)
+	err = json.Unmarshal(buf, ss)
+	require.NoError(t, err)
+	assert.Nil(t, ss.SecondaryRoles)
+}

--- a/restful.go
+++ b/restful.go
@@ -94,6 +94,16 @@ func NewAPIClientFromConfig(cfg *Config) *APIClient {
 	default:
 		apiScheme = "https"
 	}
+
+	// if role is set in config, we'd prefer to limit it as the only effective role,
+	// so you could limit the privileges by setting a role with limited privileges.
+	// however this can be overridden by executing `SET SECONDARY ROLES ALL` in the
+	// query.
+	var secondaryRoles *[]string
+	if len(cfg.Role) > 0 {
+		secondaryRoles = &[]string{}
+	}
+
 	return &APIClient{
 		cli: &http.Client{
 			Timeout: cfg.Timeout,
@@ -106,6 +116,7 @@ func NewAPIClientFromConfig(cfg *Config) *APIClient {
 		user:              cfg.User,
 		password:          cfg.Password,
 		role:              cfg.Role,
+		secondaryRoles:    secondaryRoles,
 		accessTokenLoader: initAccessTokenLoader(cfg),
 		sessionSettings:   cfg.Params,
 		statsTracker:      cfg.StatsTracker,

--- a/restful.go
+++ b/restful.go
@@ -274,8 +274,8 @@ func (c *APIClient) getPagenationConfig() *PaginationConfig {
 	}
 }
 
-func (c *APIClient) getSessionConfig() *SessionConfig {
-	return &SessionConfig{
+func (c *APIClient) getSessionConfig() *SessionState {
+	return &SessionState{
 		Database: c.database,
 		Role:     c.role,
 		Settings: c.sessionSettings,

--- a/restful.go
+++ b/restful.go
@@ -99,6 +99,9 @@ func NewAPIClientFromConfig(cfg *Config) *APIClient {
 	// so you could limit the privileges by setting a role with limited privileges.
 	// however this can be overridden by executing `SET SECONDARY ROLES ALL` in the
 	// query.
+	// secondaryRoles now have two viable values:
+	// - nil: means enabling ALL the granted roles of the user
+	// - []string{}: means enabling NONE of the granted roles
 	var secondaryRoles *[]string
 	if len(cfg.Role) > 0 {
 		secondaryRoles = &[]string{}

--- a/restful_test.go
+++ b/restful_test.go
@@ -22,7 +22,7 @@ func TestMakeHeadersUserPassword(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, headers["Authorization"], []string{"Basic cm9vdDpyb290"})
 	assert.Equal(t, headers["X-Databend-Tenant"], []string{"default"})
-	session := c.getSessionConfig()
+	session := c.getSessionState()
 	assert.Equal(t, session.Role, "role1")
 }
 


### PR DESCRIPTION
this PR made the following changes:

- handle secondary roles in the session state, which could be changed by `SET SECONDARY ROLES ALL|NONE`
- when setting `role` in the config, restricting the other granted roles not take effect by default.