### PR TITLE
fix: check batch prepare ctx with query_id

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -121,6 +121,7 @@ func (dc *DatabendConn) prepare(query string) (*databendStmt, error) {
 		return nil, err
 	}
 	dc.commit = batch.BatchInsert
+	dc.ctx = checkQueryID(dc.ctx)
 
 	stmt := &databendStmt{
 		dc:    dc,

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package godatabend
 
-var version = "0.4.2"
+var version = "0.4.9"


### PR DESCRIPTION
Fix https://github.com/datafuselabs/databend-go/issues/88