### PR TITLE
fix and refactor ApiClient and nextRows.

### DIFF
--- a/query.go
+++ b/query.go
@@ -1,7 +1,9 @@
 package godatabend
 
 import (
+	"encoding/json"
 	"fmt"
+	"strings"
 )
 
 type QueryError struct {
@@ -27,19 +29,22 @@ type DataField struct {
 }
 
 type QueryResponse struct {
-	ID        string        `json:"id"`
-	SessionID string        `json:"session_id"`
-	Session   *SessionState `json:"session"`
-	Schema    []DataField   `json:"schema"`
-	Data      [][]string    `json:"data"`
-	State     string        `json:"state"`
-	Error     *QueryError   `json:"error"`
-	Stats     QueryStats    `json:"stats"`
+	ID      string           `json:"id"`
+	Session *json.RawMessage `json:"session"`
+	Schema  *[]DataField     `json:"schema"`
+	Data    [][]string       `json:"data"`
+	State   string           `json:"state"`
+	Error   *QueryError      `json:"error"`
+	Stats   *QueryStats      `json:"stats"`
 	// TODO: Affect rows
 	StatsURI string `json:"stats_uri"`
 	FinalURI string `json:"final_uri"`
 	NextURI  string `json:"next_uri"`
 	KillURI  string `json:"kill_uri"`
+}
+
+func (r *QueryResponse) ReadFinished() bool {
+	return r.NextURI == "" || strings.Contains(r.NextURI, "/final")
 }
 
 type QueryStats struct {
@@ -62,7 +67,7 @@ type QueryRequest struct {
 	// We use client session instead of server session with session_id
 	// SessionID  string            `json:"session_id,omitempty"`
 
-	Session    *SessionState     `json:"session,omitempty"`
+	Session    *json.RawMessage  `json:"session,omitempty"`
 	SQL        string            `json:"sql"`
 	Pagination *PaginationConfig `json:"pagination,omitempty"`
 
@@ -91,9 +96,7 @@ type SessionState struct {
 	Settings map[string]string `json:"settings,omitempty"`
 
 	// txn
-	TxnState       string     `json:"txn_state,omitempty"`
-	LastServerInfo ServerInfo `json:"last_server_info,omitempty"`
-	LastQueryIds   []string   `json:"last_query_ids,omitempty"`
+	TxnState string `json:"txn_state,omitempty"`
 }
 
 type StageAttachmentConfig struct {

--- a/query_test.go
+++ b/query_test.go
@@ -17,7 +17,7 @@ func Test_SessionState(t *testing.T) {
 	}
 	buf, err := json.Marshal(ss)
 	require.NoError(t, err)
-	assert.Equal(t, "{\"database\":\"db1\",\"last_server_info\":{\"id\":\"\",\"start_time\":\"\"}}", string(buf))
+	assert.Equal(t, "{\"database\":\"db1\"}", string(buf))
 
 	buf = []byte(`{"database":"db1", "secondary_roles": []}`)
 	err = json.Unmarshal(buf, ss)

--- a/restful_test.go
+++ b/restful_test.go
@@ -42,9 +42,10 @@ func TestMakeHeadersAccessToken(t *testing.T) {
 func TestDoQuery(t *testing.T) {
 	var result QueryResponse
 	result.ID = "mockid1"
+	result.Stats = new(QueryStats)
 	mockDoRequest := func(method, path string, req interface{}, resp interface{}) error {
 		buf, _ := json.Marshal(result)
-		json.Unmarshal(buf, resp)
+		_ = json.Unmarshal(buf, resp)
 		return nil
 	}
 
@@ -63,7 +64,7 @@ func TestDoQuery(t *testing.T) {
 	}
 	queryId := "mockid1"
 	ctx := context.Background()
-	resp, err := c.DoQuery(ctx, "SELECT 1", []driver.Value{})
+	resp, err := c.StartQuery(ctx, "SELECT 1", []driver.Value{})
 	assert.NoError(t, err)
 	assert.Equal(t, gotQueryID, "mockid1")
 	assert.Equal(t, resp.ID, queryId)

--- a/rows_test.go
+++ b/rows_test.go
@@ -11,7 +11,7 @@ import (
 func TestTextRows(t *testing.T) {
 	rows, err := newNextRows(context.Background(), &DatabendConn{}, &QueryResponse{
 		Data: [][]string{{"1", "2", "3"}, {"3", "2", "1"}},
-		Schema: []DataField{
+		Schema: &[]DataField{
 			{Name: "age", Type: "Int32"},
 			{Name: "height", Type: "Int64"},
 			{Name: "score", Type: "String"},

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -35,6 +35,10 @@ var (
 
 func init() {
 	dsn = os.Getenv("TEST_DATABEND_DSN")
+	// databend default
+	// dsn = "http://root:@localhost:8000?presigned_url_disabled=true"
+
+	// add user databend by uncommenting corresponding [[query.users]] section scripts/ci/deploy/config/databend-query-node-1.toml
 	//dsn = "http://databend:databend@localhost:8000?presigned_url_disabled=true"
 }
 
@@ -69,7 +73,7 @@ func (s *DatabendTestSuite) SetupSuite() {
 }
 
 func (s *DatabendTestSuite) TearDownSuite() {
-	s.db.Close()
+	_ = s.db.Close()
 }
 
 func (s *DatabendTestSuite) SetupTest() {
@@ -114,7 +118,7 @@ func (s *DatabendTestSuite) TestQuoteStringQuery() {
 	rows, err := s.db.Query(fmt.Sprintf("select * from %s", s.table2))
 	for rows.Next() {
 		var t string
-		rows.Scan(&t)
+		_ = rows.Scan(&t)
 		s.r.Equal(string(x), t)
 	}
 }
@@ -126,7 +130,7 @@ func (s *DatabendTestSuite) TestDesc() {
 	result, err := scanValues(rows)
 	s.r.Nil(err)
 	s.r.Equal([][]interface{}{{"i64", "BIGINT", "YES", "NULL", ""}, {"u64", "BIGINT UNSIGNED", "YES", "NULL", ""}, {"f64", "DOUBLE", "YES", "NULL", ""}, {"s", "VARCHAR", "YES", "NULL", ""}, {"s2", "VARCHAR", "YES", "NULL", ""}, {"a16", "ARRAY(INT16)", "YES", "NULL", ""}, {"a8", "ARRAY(UINT8)", "YES", "NULL", ""}, {"d", "DATE", "YES", "NULL", ""}, {"t", "TIMESTAMP", "YES", "NULL", ""}}, result)
-	rows.Close()
+	_ = rows.Close()
 }
 
 func (s *DatabendTestSuite) TestBasicSelect() {
@@ -275,7 +279,7 @@ func (s *DatabendTestSuite) TestTransactionCommit() {
 
 	result, err := scanValues(rows)
 	s.r.Nil(err)
-	s.r.Equal([][]interface{}{[]interface{}{"1", "NULL", "NULL", "NULL", "NULL", "NULL", "NULL", "NULL", "NULL"}}, result)
+	s.r.Equal([][]interface{}{{"1", "NULL", "NULL", "NULL", "NULL", "NULL", "NULL", "NULL", "NULL"}}, result)
 
 	s.r.NoError(rows.Close())
 }

--- a/tests/session_test.go
+++ b/tests/session_test.go
@@ -3,8 +3,6 @@ package tests
 import (
 	"database/sql"
 	"fmt"
-	"os"
-
 	"github.com/stretchr/testify/require"
 )
 
@@ -34,17 +32,16 @@ func (s *DatabendTestSuite) TestChangeRole() {
 	println(result)
 	_, err = s.db.Exec("create role if not exists test_role")
 	r.Nil(err)
-	dsn := os.Getenv("TEST_DATABEND_DSN")
+
 	s.NotEmpty(dsn)
-	dsn = fmt.Sprintf("%s&role=test_role", dsn)
-	s.db, err = sql.Open("databend", dsn)
+	dsn_with_role := fmt.Sprintf("%s&role=test_role", dsn)
+	s.db, err = sql.Open("databend", dsn_with_role)
 	s.Nil(err)
 
 	err = s.db.QueryRow("select current_role()").Scan(&result)
 	r.Nil(err)
 	r.Equal("test_role", result)
 
-	dsn = os.Getenv("TEST_DATABEND_DSN")
 	s.NotEmpty(dsn)
 	s.db, err = sql.Open("databend", dsn)
 	s.Nil(err)

--- a/transaction.go
+++ b/transaction.go
@@ -21,7 +21,7 @@ func (tx *databendTx) Commit() (err error) {
 			return
 		}
 	}
-	// complicity with old server version
+	// compatible with old server version
 	if tx.dc.rest.sessionState.TxnState != "" {
 		_, err = tx.dc.exec(tx.dc.ctx, "COMMIT")
 		if err != nil {


### PR DESCRIPTION


1. ensure closed exactly once and close as early as possible.
2. use sessionStateRaw for compatibility.
3. unify retry policy.
4. allow QueryResponse.Schema to be nil.
5. one place to call NextQuery().
6. better code reuse to easy maintain. 
7. allow QueryResponse.Stats to be nil.
8. fix warnings.