### PR TITLE
feat: support ctx propagate UA

### DIFF
--- a/con_batch.go
+++ b/con_batch.go
@@ -94,6 +94,7 @@ func (b *httpBatch) AppendToFile(v []driver.Value) error {
 }
 
 func (b *httpBatch) UploadToStage(ctx context.Context) (*StageLocation, error) {
+	ctx = checkQueryID(ctx)
 	fi, err := os.Stat(b.batchFile)
 	if err != nil {
 		return nil, errors.Wrap(err, "get batch file size failed")

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package godatabend
 
-var version = "0.5.9"
+var version = "0.6.0"

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package godatabend
 
-var version = "0.5.1"
+var version = "0.5.9"


### PR DESCRIPTION
We can use:

```
ctx := context.WithValue()
sql.ExecuteContext(ctx, sql)
```

to propagate info to query server.